### PR TITLE
Fallback to /index.html when launch_path is missing in manifest

### DIFF
--- a/dom/apps/AppsUtils.jsm
+++ b/dom/apps/AppsUtils.jsm
@@ -956,7 +956,7 @@ ManifestHelper.prototype = {
       if (this._localeProp("start_url")) {
         return this._baseURI.resolve(this._localeProp("start_url") || "/");
       }
-      return this._baseURI.resolve(this._localeProp("launch_path") || "/");
+      return this._baseURI.resolve(this._localeProp("launch_path") || "/index.html");
     }
 
     // Search for the l10n entry_points property.


### PR DESCRIPTION
e.g calculator app preloaded from the marketplace has a online
manifest (https://marketplace.firefox.com/app/9f96ce77-5b2d-42ca-a0d9-10a933dd84c4/manifest.webapp)
which doens't have a launch_path (while the package one has
a launch_path).
With this change the app opens correctly.

@autra : r?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/phoxygen/gecko-dev/4)

<!-- Reviewable:end -->
